### PR TITLE
Made ChatStrings2 always mirror ChatStrings1

### DIFF
--- a/Universal.lua
+++ b/Universal.lua
@@ -24,9 +24,6 @@ local Table = {
     ChatStrings1 = {
         ["HYPE73WZNQRT5"] = "Aristois",
     },
-    ChatStrings2 = {
-        ["Aristois"] = "HYPE73WZNQRT5",
-    },
     checkedPlayers = {},
     Box = function()
         local boxHandleAdornment = Instance.new("BoxHandleAdornment")
@@ -39,6 +36,14 @@ local Table = {
         return boxHandleAdornment
     end
 }
+tempF = function()
+    local tempT = {}
+    for i, x in pairs(Table.ChatStrings1) do
+        tempT[x] = i
+    end
+	return tempT
+end
+Table.ChatStrings2 = tempF()
 
 local RunLoops = {RenderStepTable = {}, StepTable = {}, HeartTable = {}}
 local Window = GuiLibrary:CreateWindow({


### PR DESCRIPTION
This removes the need to change ChatStrings2 alongside ChatStrings1, which also removes the chance of human error. (This pull request can be denied if you believe no partners will ever be added to the tables(which would remove the need for the tables))